### PR TITLE
Fix iOS requirement docs

### DIFF
--- a/docs/README-ios.md
+++ b/docs/README-ios.md
@@ -2,7 +2,7 @@ iOS
 ======
 
 ==============================================================================
-Building the Simple DirectMedia Layer for iOS 5.1+
+Building the Simple DirectMedia Layer for iOS
 ==============================================================================
 
 Requirements: Mac OS X 10.8 or later and the iOS 7+ SDK.


### PR DESCRIPTION
The text said build for 5.1, but next line has "requires 7"